### PR TITLE
Add support for stream operators

### DIFF
--- a/tEndian.h
+++ b/tEndian.h
@@ -29,6 +29,7 @@
 
 #include <cassert>
 #include <cstdint>
+#include <iostream>
 
 //Both tLittleEndian and tBigEndian are manufactured primitives
 //that are essentially immutable except for the assignment operators.
@@ -131,6 +132,8 @@ public:
     tLittleEndian& operator ^=(const T& b)  { *this = T(*this) ^ b; return *this; }
     tLittleEndian& operator <<=(const T& b) { *this = T(T(*this) << b); return *this; }
     tLittleEndian& operator >>=(const T& b) { *this = T(T(*this) >> b); return *this; }
+    friend std::ostream& operator <<(std::ostream &out, const tLittleEndian b) { out << T(b); return out; }
+    friend std::istream& operator >>(std::istream &in, tLittleEndian &b)       { in >> b.mData;    return in; }
 };
 
 template<typename T>
@@ -183,6 +186,8 @@ public:
     tBigEndian& operator ^=(const T& b)  { *this = T(*this) ^ b; return *this; }
     tBigEndian& operator <<=(const T& b) { *this = T(T(*this) << b); return *this; }
     tBigEndian& operator >>=(const T& b) { *this = T(T(*this) >> b); return *this; }
+    friend std::ostream& operator <<(std::ostream &out, const tBigEndian b) { out << T(b); return out; }
+    friend std::istream& operator >>(std::istream &in, tBigEndian &b)       { T val; in >> val; b = val;    return in; }
 };
 
 typedef tLittleEndian<int16_t>      leint16;


### PR DESCRIPTION
Currently you can't `std::out <<` or `std::in >>` to enter or print values from the typedefs, this adds that functionality